### PR TITLE
Updated references to use Inspection_oM and Cleaned Up Pull Workflow

### DIFF
--- a/iAuditor_Adapter/CRUD/Read.cs
+++ b/iAuditor_Adapter/CRUD/Read.cs
@@ -28,7 +28,7 @@ using System.Linq;
 using BH.Adapter.iAuditor;
 using BH.oM.Base;
 using BH.oM.Adapter;
-using BH.oM.Adapter.iAuditor;
+using BH.oM.Inspection;
 using BH.oM.Adapters.iAuditor;
 using BH.oM.Adapters.HTTP;
 using BH.Engine.Adapters.HTTP;
@@ -103,7 +103,7 @@ namespace BH.Adapter.iAuditor
             if (id == null)
             {
                 Engine.Reflection.Compute.RecordError("No audit ID provided. Please provide an audit ID using an iAuditorConfig ActionConfig.");
-                return new List<BH.oM.Adapters.iAuditor.Audit>();
+                return new List<BH.oM.Inspection.Audit>();
             }
             else
             { getRequest = BH.Engine.Adapters.iAuditor.Create.IAuditorRequest("audits/" + id, m_bearerToken); }

--- a/iAuditor_Adapter/iAuditor_Adapter.cs
+++ b/iAuditor_Adapter/iAuditor_Adapter.cs
@@ -46,13 +46,12 @@ namespace BH.Adapter.iAuditor
         [Input("password", "Provide iAuditor Password")]
         [Input("token", "Provide iAuditor token instead of username and pw")]
         [Output("adapter", "Adapter results")]
-        public iAuditorAdapter(string username = "", string password = "", string token = "", bool active = false)
+        public iAuditorAdapter(string username = "", string password = "", string token = null, bool active = false)
         {
             AdapterIdName = "iAuditorAdapter";
             if (active)
             {
-                //m_bearerToken = Compute.BearerToken(username, password);
-                m_bearerToken = token;
+                m_bearerToken = token ?? Compute.BearerToken(username, password);
             }
         }
 

--- a/iAuditor_Adapter/iAuditor_Adapter.csproj
+++ b/iAuditor_Adapter/iAuditor_Adapter.csproj
@@ -47,6 +47,10 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Geometry_oM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_oM.dll</HintPath>
+	  <Private>False</Private>
+    </Reference>
     <Reference Include="HTTP_Engine">
       <HintPath>C:\ProgramData\BHoM\Assemblies\HTTP_Engine.dll</HintPath>
       <Private>False</Private>
@@ -54,6 +58,9 @@
     <Reference Include="HTTP_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\HTTP_oM.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="Inspection_oM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Inspection_oM.dll</HintPath>
     </Reference>
     <Reference Include="Reflection_Engine">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>

--- a/iAuditor_oM/Adapter/iAuditorConfig.cs
+++ b/iAuditor_oM/Adapter/iAuditorConfig.cs
@@ -24,7 +24,7 @@ using BH.oM.Adapter;
 using System.Collections.Generic;
 using System.ComponentModel;
 
-namespace BH.oM.Adapter.iAuditor
+namespace BH.oM.Adapters.iAuditor
 {
     [Description("This Config can be specified in the `ActionConfig` input of any Adapter Action (e.g. Push).")]
     // Note: this will get passed within any CRUD method (see their signature). 

--- a/iAuditor_oM/iAuditor_oM.csproj
+++ b/iAuditor_oM/iAuditor_oM.csproj
@@ -54,10 +54,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Adapter\iAuditorConfig.cs" />
-    <Compile Include="InstallationProgress.cs" />
-    <Compile Include="Comment.cs" />
-    <Compile Include="Issue.cs" />
-    <Compile Include="Audit.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
 
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #7 
Closes #11 
Closes #12 
Closes #13 


Added issue date and audit information for issue pushing independent of audits. Fixed bugs when pulling certain issues without media. Added issue numbering and naming per standards and to allow for downstream workflows with issues numbered to maintain consistent issue tracking. Fixed credential handling for username/password adapter option. Updated references to use central Inspection_oM and removed corresponding objects from IAuditor.


### Test files
Previous test files for standard pull workflow apply. Confirm functionality, required properties on issues (name, issue date, issue number) and test with multiple test audits to ensure different media / issue pull cases are covered.


### Changelog
- Updated references to `Inspection_oM` and removed `Inspection_oM` objects from `IAuditor`
- Added issue number, issue name, and issue date to pull functionality so that `Issues` can function as standalone elements
- Fixed bug when pulling `Issue` without associated `Media`
- Added credential handling for username and password credential option
