### PR TITLE
Inspection_oM: Added two new properties to Issues

### DIFF
--- a/iAuditor_Adapter/CRUD/Read.cs
+++ b/iAuditor_Adapter/CRUD/Read.cs
@@ -62,7 +62,7 @@ namespace BH.Adapter.iAuditor
         /***************************************************/
         /**** Private specific read methods             ****/
         /***************************************************/
-        private List<Audit> ReadAudit(List<string> ids = null, iAuditorConfig config = null)
+        private List<List<BHoMObject>> ReadAudit(List<string> ids = null, iAuditorConfig config = null)
         {
             //Add parameters per config
             CustomObject requestParams = new CustomObject();
@@ -103,7 +103,7 @@ namespace BH.Adapter.iAuditor
             if (id == null)
             {
                 Engine.Reflection.Compute.RecordError("No audit ID provided. Please provide an audit ID using an iAuditorConfig ActionConfig.");
-                return new List<BH.oM.Inspection.Audit>();
+                return null;
             }
             else
             { getRequest = BH.Engine.Adapters.iAuditor.Create.IAuditorRequest("audits/" + id, m_bearerToken); }
@@ -134,8 +134,8 @@ namespace BH.Adapter.iAuditor
                 return null;
             }
 
-            //Convert nested customObject from serialization to list of epdData objects
-            List<Audit> audits = new List<Audit>();
+            //Convert nested customObject from serialization to lists of audits and issues
+            List<List<BHoMObject>> auditsAndIssues = new List<List<BHoMObject>>();
 
             object auditObjects = Engine.Reflection.Query.PropertyValue(responseObjs[0], "Objects");
 
@@ -144,12 +144,12 @@ namespace BH.Adapter.iAuditor
             {
                 foreach (CustomObject co in objList)
                 {
-                    Audit audit = Convert.ToAudit(co, m_bearerToken, targetPath, includeAssetFiles);
-                    audits.Add(audit);
+                    List<BHoMObject> auditAndIssues = Convert.ToAudit(co, m_bearerToken, targetPath, includeAssetFiles);
+                    auditsAndIssues.Add(auditAndIssues);
                 }
             }
 
-            return audits;
+            return auditsAndIssues;
         }
 
     }

--- a/iAuditor_Adapter/Convert/ToBHoM.cs
+++ b/iAuditor_Adapter/Convert/ToBHoM.cs
@@ -48,7 +48,7 @@ namespace BH.Adapter.iAuditor
         /****           Public Methods                  ****/
         /***************************************************/
 
-        public static List<BHoMObject> ToAudit(this CustomObject obj, string bearerToken, string targetPath, bool includeAssetFiles = true)
+        public static Audit ToAudit(this CustomObject obj, string targetPath, string bearerToken, bool includeAssetFiles = true)
         {
             List<BHoMObject> auditAndIssues = new List<BHoMObject>();
             string projectNumber = "";
@@ -176,7 +176,7 @@ namespace BH.Adapter.iAuditor
             }
 
             installProgress = obj.ToInstallationProgressObjects();
-            issues = obj.ToIssues(targetPath, includeAssetFiles);
+            issues = obj.ToIssues(targetPath, false);
             List<string> issueIDs = new List<string>();
             foreach (Issue issue in issues)
             {
@@ -208,10 +208,7 @@ namespace BH.Adapter.iAuditor
                 Score = obj.PropertyValue("audit_data.score_percentage")?.ToString() ?? "",
             };
 
-            auditAndIssues.Add(audit);
-            auditAndIssues.AddRange(issues);
-
-            return auditAndIssues;
+            return audit;
         }
 
         /***************************************************/
@@ -317,7 +314,7 @@ namespace BH.Adapter.iAuditor
             List<object> commentIDList = obj.PropertyValue("children") as List<object>;
             commentIDList.ForEach(x => commentElemIDs.Add(x.ToString()));
             List<object> items = auditCustomObject.PropertyValue("items") as List<object>;
-            string auditID = obj.PropertyValue("audit_id")?.ToString() ?? "";
+            string auditID = auditCustomObject.PropertyValue("audit_id")?.ToString() ?? "";
 
             List<string> media = new List<string>();
             string priority = "";

--- a/iAuditor_Adapter/Convert/ToBHoM.cs
+++ b/iAuditor_Adapter/Convert/ToBHoM.cs
@@ -48,8 +48,9 @@ namespace BH.Adapter.iAuditor
         /****           Public Methods                  ****/
         /***************************************************/
 
-        public static Audit ToAudit(this CustomObject obj, string bearerToken, string targetPath, bool includeAssetFiles = true)
+        public static List<BHoMObject> ToAudit(this CustomObject obj, string bearerToken, string targetPath, bool includeAssetFiles = true)
         {
+            List<BHoMObject> auditAndIssues = new List<BHoMObject>();
             string projectNumber = "";
             int visitNo = 0;
             int revNo = 0;
@@ -176,6 +177,11 @@ namespace BH.Adapter.iAuditor
 
             installProgress = obj.ToInstallationProgressObjects();
             issues = obj.ToIssues(targetPath, includeAssetFiles);
+            List<string> issueIDs = new List<string>();
+            foreach (Issue issue in issues)
+            {
+                issueIDs.Add(issue.IssueNumber);
+            }
 
             Audit audit = new Audit
             {
@@ -202,7 +208,10 @@ namespace BH.Adapter.iAuditor
                 Score = obj.PropertyValue("audit_data.score_percentage")?.ToString() ?? "",
             };
 
-            return audit;
+            auditAndIssues.Add(audit);
+            auditAndIssues.AddRange(issues);
+
+            return auditAndIssues;
         }
 
         /***************************************************/
@@ -308,6 +317,8 @@ namespace BH.Adapter.iAuditor
             List<object> commentIDList = obj.PropertyValue("children") as List<object>;
             commentIDList.ForEach(x => commentElemIDs.Add(x.ToString()));
             List<object> items = auditCustomObject.PropertyValue("items") as List<object>;
+            string auditID = obj.PropertyValue("audit_id")?.ToString() ?? "";
+
             List<string> media = new List<string>();
             string priority = "";
             string status = "";
@@ -384,6 +395,7 @@ namespace BH.Adapter.iAuditor
 
             Issue issue = new Issue
             {
+                AuditID = auditID,
                 Description = description,
                 DateCreated = issueDate,
                 IssueNumber = issueNumber,

--- a/iAuditor_Adapter/Convert/ToBHoM.cs
+++ b/iAuditor_Adapter/Convert/ToBHoM.cs
@@ -204,7 +204,7 @@ namespace BH.Adapter.iAuditor
                 VisitPurpose = purpose,
                 AreasInspected = areas,
                 InstallationProgressObjects = installProgress,
-                Issues = issues,
+                IssueNumbers = issueIDs,
                 Score = obj.PropertyValue("audit_data.score_percentage")?.ToString() ?? "",
             };
 

--- a/iAuditor_Adapter/iAuditor_Adapter.cs
+++ b/iAuditor_Adapter/iAuditor_Adapter.cs
@@ -52,6 +52,10 @@ namespace BH.Adapter.iAuditor
             {
                 m_bearerToken = token ?? Compute.BearerToken(username, password);
             }
+            else
+            {
+                m_bearerToken = null;
+            }
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
https://github.com/BHoM/BHoM/pull/1178

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #38 

Restructured audits and issues so they are returned independently to align with usage of issues (persistent, changed downstream) and audits (pulled once and left as is), and to align to new properties added to oM accordingly.


### Test files
Test file [here](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/iAuditor_Toolkit/%2339-AddedTwoNewPropertiesToIssues?csf=1&web=1&e=lSFCdn).

Pull any audit as per previous scripts and confirm audit as well as issues are returned, with the audit maintaining issue numbers but not the issues themselves.