### PR TITLE
Added method to get latest unique issues from list of issues

### DIFF
--- a/iAuditor_Engine/Query/LatestIssues.cs
+++ b/iAuditor_Engine/Query/LatestIssues.cs
@@ -39,7 +39,7 @@ namespace BH.Engine.Adapters.iAuditor
         [Description("Returns the latest unique instance of each Issue from a chronological list of Issues.")]
         [Input("allIssues", "All Issues, potentially including duplicates of modified Issues. This list is assumed to be chronological from oldest to newest.")]
         [Output("latestIssues", "The latest instance of each unique Issue included in the provided collection of Issues.")]
-        public static List<Issue> LatestIssues(List<Issue> allIssues)
+        public static List<Issue> LatestIssues(this List<Issue> allIssues)
         {
             allIssues.Reverse();
             List<Issue> result = allIssues

--- a/iAuditor_Engine/Query/LatestIssues.cs
+++ b/iAuditor_Engine/Query/LatestIssues.cs
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+ 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Net;
+using System.Net.Http;
+using System.ComponentModel;
+using System.Web;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Inspection;
+
+namespace BH.Engine.Adapters.iAuditor
+{
+    public static partial class Query
+    {
+        [Description("Returns the latest unique instance of each Issue from a chronological list of Issues.")]
+        [Input("allIssues", "All Issues, potentially including duplicates of modified Issues. This list is assumed to be chronological from oldest to newest.")]
+        [Output("latestIssues", "The latest instance of each unique Issue included in the provided collection of Issues.")]
+        public static List<Issue> LatestIssues(List<Issue> allIssues)
+        {
+            allIssues.Reverse();
+            List<Issue> result = allIssues
+                .OrderBy(x => x.IssueNumber)
+                .GroupBy(x => x.IssueNumber)
+                .Select(g => g.First())
+                .ToList();
+            return result;
+        }
+    }
+}
+

--- a/iAuditor_Engine/iAuditor_Engine.csproj
+++ b/iAuditor_Engine/iAuditor_Engine.csproj
@@ -43,6 +43,10 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\HTTP_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Inspection_oM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Inspection_oM.dll</HintPath>
+	  <Private>False</Private>
+    </Reference>
     <Reference Include="LifeCycleAssessment_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\LifeCycleAssessment_oM.dll</HintPath>
       <Private>False</Private>
@@ -68,10 +72,10 @@
     <Compile Include="Compute\BearerToken.cs" />
     <Compile Include="Create\IAuditorRequest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Query\LatestIssues.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Modify\" />
-    <Folder Include="Query\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\iAuditor_oM\iAuditor_oM.csproj">


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #44 

This new method allows us to get the latest unique instance of each Issue from a collection of issues that includes duplicates of issues for each time it has been modified.


### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/iAuditor_Toolkit/%2344-GetLatestIssues?csf=1&web=1&e=ptbxG5
