### PR TITLE
Fixed media pull bug by moving asset file request to Media convert and updating methods accordingly

### DIFF
--- a/iAuditor_Adapter/CRUD/Read.cs
+++ b/iAuditor_Adapter/CRUD/Read.cs
@@ -93,8 +93,8 @@ namespace BH.Adapter.iAuditor
             CustomObject co = requestResponseObject as CustomObject;
             if (co != null)
             {
-                    List<Issue> issueList = Convert.ToIssues(co, config.AssetFilePath, config.IncludeAssetFiles);
-                    issues.AddRange(issueList);
+                List<Issue> issueList = Convert.ToIssues(co, config.AssetFilePath, m_bearerToken, config.IncludeAssetFiles);
+                issues.AddRange(issueList);
             }
 
             return issues;


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #47 

When pulling Audits now, only the installation progress media is pulled, while the issue specific media is pulled with each specific issue when pulling issues.


### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/iAuditor_Toolkit/%2347-PullMediaFix?csf=1&web=1&e=Bax70Q
